### PR TITLE
Add integration test using actual 0xAPI response and Mainnet Exchange Proxy

### DIFF
--- a/contracts/exchangeIssuance/ExchangeIssuanceZeroEx.sol
+++ b/contracts/exchangeIssuance/ExchangeIssuanceZeroEx.sol
@@ -191,6 +191,14 @@ contract ExchangeIssuanceZeroEx is Ownable, ReentrancyGuard {
             uint256 inputTokenSpent;
             _safeApprove(_inputToken, swapTarget, _maxAmountInputToken);
 
+            console.log("Input Token Balance:");
+            uint256 inputTokenBalance = _inputToken.balanceOf(address(this));
+            console.log("Contract");
+            console.logUint(inputTokenBalance);
+            uint256 inputTokenBalanceSender = _inputToken.balanceOf(msg.sender);
+            console.log("Sender");
+            console.logUint(inputTokenBalanceSender);
+
             (maxAmountWETH, inputTokenSpent) = _fillQuote(_inputQuote);
             require(inputTokenSpent <= _maxAmountInputToken, "OVERSPENT INPUTTOKEN");
             uint256 amountInputTokenReturn = _maxAmountInputToken.sub(inputTokenSpent);
@@ -438,8 +446,9 @@ contract ExchangeIssuanceZeroEx is Ownable, ReentrancyGuard {
         console.log("Calling Swap target");
         console.logAddress(address(swapTarget));
         console.logBytes(_quote.swapCallData);
-        (bool success,) = swapTarget.call(_quote.swapCallData);
-        require(success, "SWAP CALL FAILED");
+        (bool success, bytes memory returndata) = swapTarget.call(_quote.swapCallData);
+        require(success, string(returndata));
+        console.log("Called Swap target");
 
         // TODO: check if we want to do this / and how to do so savely
         // Refund any unspent protocol fees to the sender.

--- a/contracts/exchangeIssuance/ExchangeIssuanceZeroEx.sol
+++ b/contracts/exchangeIssuance/ExchangeIssuanceZeroEx.sol
@@ -27,6 +27,7 @@ import { IController } from "../interfaces/IController.sol";
 import { ISetToken } from "../interfaces/ISetToken.sol";
 import { IWETH } from "../interfaces/IWETH.sol";
 import { PreciseUnitMath } from "../lib/PreciseUnitMath.sol";
+import "hardhat/console.sol";
 
 contract ExchangeIssuanceZeroEx is Ownable, ReentrancyGuard {
 
@@ -434,6 +435,9 @@ contract ExchangeIssuanceZeroEx is Ownable, ReentrancyGuard {
         uint256 buyTokenBalanceBefore = _quote.buyToken.balanceOf(address(this));
         uint256 sellTokenBalanceBefore = _quote.sellToken.balanceOf(address(this));
 
+        console.log("Calling Swap target");
+        console.logAddress(address(swapTarget));
+        console.logBytes(_quote.swapCallData);
         (bool success,) = swapTarget.call(_quote.swapCallData);
         require(success, "SWAP CALL FAILED");
 

--- a/contracts/exchangeIssuance/ExchangeIssuanceZeroEx.sol
+++ b/contracts/exchangeIssuance/ExchangeIssuanceZeroEx.sol
@@ -27,7 +27,6 @@ import { IController } from "../interfaces/IController.sol";
 import { ISetToken } from "../interfaces/ISetToken.sol";
 import { IWETH } from "../interfaces/IWETH.sol";
 import { PreciseUnitMath } from "../lib/PreciseUnitMath.sol";
-import "hardhat/console.sol";
 
 contract ExchangeIssuanceZeroEx is Ownable, ReentrancyGuard {
 
@@ -191,13 +190,8 @@ contract ExchangeIssuanceZeroEx is Ownable, ReentrancyGuard {
             uint256 inputTokenSpent;
             _safeApprove(_inputToken, swapTarget, _maxAmountInputToken);
 
-            console.log("Input Token Balance:");
             uint256 inputTokenBalance = _inputToken.balanceOf(address(this));
-            console.log("Contract");
-            console.logUint(inputTokenBalance);
             uint256 inputTokenBalanceSender = _inputToken.balanceOf(msg.sender);
-            console.log("Sender");
-            console.logUint(inputTokenBalanceSender);
 
             (maxAmountWETH, inputTokenSpent) = _fillQuote(_inputQuote);
             require(inputTokenSpent <= _maxAmountInputToken, "OVERSPENT INPUTTOKEN");
@@ -443,12 +437,8 @@ contract ExchangeIssuanceZeroEx is Ownable, ReentrancyGuard {
         uint256 buyTokenBalanceBefore = _quote.buyToken.balanceOf(address(this));
         uint256 sellTokenBalanceBefore = _quote.sellToken.balanceOf(address(this));
 
-        console.log("Calling Swap target");
-        console.logAddress(address(swapTarget));
-        console.logBytes(_quote.swapCallData);
         (bool success, bytes memory returndata) = swapTarget.call(_quote.swapCallData);
         require(success, string(returndata));
-        console.log("Called Swap target");
 
         // TODO: check if we want to do this / and how to do so savely
         // Refund any unspent protocol fees to the sender.

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -11,9 +11,10 @@ import "./tasks";
 
 const forkingConfig = {
   url: "https://eth-mainnet.alchemyapi.io/v2/" + process.env.ALCHEMY_TOKEN,
+  blockNumber: process.env.LATESTBLOCK ? undefined : 11649166,
 };
 
-const INTEGRATIONTEST_TIMEOUT = 100000;
+const INTEGRATIONTEST_TIMEOUT = 300000;
 
 const mochaConfig = {
   grep: "@forked-network",
@@ -44,7 +45,7 @@ const config: HardhatUserConfig = {
       url: "http://127.0.0.1:8545",
       gas: 12000000,
       blockGasLimit: 12000000,
-      timeout: INTEGRATIONTEST_TIMEOUT,
+      timeout:  INTEGRATIONTEST_TIMEOUT,
     },
     kovan: {
       url: "https://kovan.infura.io/v3/" + process.env.INFURA_TOKEN,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -13,10 +13,12 @@ const forkingConfig = {
   url: "https://eth-mainnet.alchemyapi.io/v2/" + process.env.ALCHEMY_TOKEN,
 };
 
+const INTEGRATIONTEST_TIMEOUT = 100000;
+
 const mochaConfig = {
   grep: "@forked-network",
-  invert: (process.env.FORK) ? false : true,
-  timeout: (process.env.FORK) ? 50000 : 40000,
+  invert: process.env.FORK ? false : true,
+  timeout: process.env.INTEGRATIONTEST ? INTEGRATIONTEST_TIMEOUT : process.env.FORK ? 50000 : 40000,
 } as Mocha.MochaOptions;
 
 const config: HardhatUserConfig = {
@@ -31,15 +33,18 @@ const config: HardhatUserConfig = {
   },
   networks: {
     hardhat: {
-      forking: (process.env.FORK) ? forkingConfig : undefined,
+      forking: process.env.FORK ? forkingConfig : undefined,
       accounts: getHardhatPrivateKeys(),
       gas: 12000000,
       blockGasLimit: 12000000,
+      // @ts-ignore
+      timeout: process.env.FORK ? INTEGRATIONTEST_TIMEOUT : 20000,
     },
     localhost: {
       url: "http://127.0.0.1:8545",
       gas: 12000000,
       blockGasLimit: 12000000,
+      timeout: process.env.INTEGRATIONTEST ? INTEGRATIONTEST_TIMEOUT : 20000,
     },
     kovan: {
       url: "https://kovan.infura.io/v3/" + process.env.INFURA_TOKEN,
@@ -60,7 +65,7 @@ const config: HardhatUserConfig = {
 };
 
 function getHardhatPrivateKeys() {
-  return privateKeys.map(key => {
+  return privateKeys.map((key) => {
     const TEN_MILLION_ETH = "10000000000000000000000000";
     return {
       privateKey: key,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -38,13 +38,13 @@ const config: HardhatUserConfig = {
       gas: 12000000,
       blockGasLimit: 12000000,
       // @ts-ignore
-      timeout: process.env.FORK ? INTEGRATIONTEST_TIMEOUT : 20000,
+      timeout: INTEGRATIONTEST_TIMEOUT,
     },
     localhost: {
       url: "http://127.0.0.1:8545",
       gas: 12000000,
       blockGasLimit: 12000000,
-      timeout: process.env.INTEGRATIONTEST ? INTEGRATIONTEST_TIMEOUT : 20000,
+      timeout: INTEGRATIONTEST_TIMEOUT,
     },
     kovan: {
       url: "https://kovan.infura.io/v3/" + process.env.INFURA_TOKEN,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -11,7 +11,6 @@ import "./tasks";
 
 const forkingConfig = {
   url: "https://eth-mainnet.alchemyapi.io/v2/" + process.env.ALCHEMY_TOKEN,
-  blockNumber: 13615797,
 };
 
 const mochaConfig = {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -11,7 +11,7 @@ import "./tasks";
 
 const forkingConfig = {
   url: "https://eth-mainnet.alchemyapi.io/v2/" + process.env.ALCHEMY_TOKEN,
-  blockNumber: 11649166,
+  blockNumber: 13615797,
 };
 
 const mochaConfig = {

--- a/test/exchangeIssuance/exchangeIssuanceZeroEx.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuanceZeroEx.spec.ts
@@ -537,8 +537,8 @@ describe("ExchangeIssuanceZeroEx", async () => {
           const positionQuotes: ZeroExSwapQuote[] = [];
           let buyAmountWeth = BigNumber.from(0);
 
-          console.log("Getting quotes for component trades");
           for (const position of positions) {
+            console.log("\n\n###################COMPONENT QUOTE##################");
             const buyAmount = position.unit.mul(setAmount).toString();
             const buyToken = position.component;
             const sellToken = wethAddress;
@@ -552,7 +552,7 @@ describe("ExchangeIssuanceZeroEx", async () => {
             buyAmountWeth = buyAmountWeth.add(BigNumber.from(quote.sellAmount));
           }
 
-          console.log("Getting quote for input token trade");
+          console.log("\n\n###################INPUT TOKEN QUOTE##################");
           const inputTokenApiResponse = await getQuote({
             buyToken: wethAddress,
             sellToken: inputTokenAddress,
@@ -595,6 +595,8 @@ describe("ExchangeIssuanceZeroEx", async () => {
         beforeEach(async () => {
           await initializeSubjectVariables();
           await exchangeIssuanceZeroEx.approveSetToken(setToken.address);
+
+          console.log("\n\n###################OBTAIN INPUT TOKEN FROM WHALE##################");
           const inputTokenWhaleAddress = "0x21a31Ee1afC51d94C2eFcCAa2092aD1028285549";
           await hre.network.provider.request({
             method: "hardhat_impersonateAccount",
@@ -614,7 +616,6 @@ describe("ExchangeIssuanceZeroEx", async () => {
         });
 
         async function subject(): Promise<ContractTransaction> {
-          console.log("calling subject");
           return await exchangeIssuanceZeroEx.issueExactSetFromToken(
             setToken.address,
             subjectInputToken.address,

--- a/test/exchangeIssuance/exchangeIssuanceZeroEx.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuanceZeroEx.spec.ts
@@ -590,18 +590,19 @@ describe("ExchangeIssuanceZeroEx", async () => {
           });
           const inputTokenWhaleSigner = ethers.provider.getSigner(inputTokenWhaleAddress);
           const whaleTokenBalance = await subjectInputToken.balanceOf(inputTokenWhaleAddress);
-          const transferTx = await subjectInputToken
+          await subjectInputToken
             .connect(inputTokenWhaleSigner)
             .transfer(owner.address, whaleTokenBalance);
-          await transferTx.wait();
           console.log(
             "New owner balance",
             (await subjectInputToken.balanceOf(owner.address)).toString(),
           );
           subjectInputToken.approve(exchangeIssuanceZeroEx.address, MAX_UINT_256);
+          subjectInputTokenAmount = await subjectInputToken.balanceOf(owner.address);
         });
 
         async function subject(): Promise<ContractTransaction> {
+          console.log("calling subject");
           return await exchangeIssuanceZeroEx.issueExactSetFromToken(
             setToken.address,
             subjectInputToken.address,
@@ -612,16 +613,16 @@ describe("ExchangeIssuanceZeroEx", async () => {
           );
         }
 
-        it("should be able to execute input swap directly", async () => {
-          const transactionRequest = {
-            to: zeroExProxyAddress,
-            data: subjectInputSwapQuote.swapCallData,
-          };
-          subjectInputToken.approve(zeroExProxyAddress, MAX_UINT_256);
-          const [signer] = await ethers.getSigners();
-          const tx = await signer.sendTransaction(transactionRequest);
-          await tx.wait();
-        });
+        // it("should be able to execute input swap directly", async () => {
+        //   const transactionRequest = {
+        //     to: zeroExProxyAddress,
+        //     data: subjectInputSwapQuote.swapCallData,
+        //   };
+        //   subjectInputToken.approve(zeroExProxyAddress, MAX_UINT_256);
+        //   const [signer] = await ethers.getSigners();
+        //   const tx = await signer.sendTransaction(transactionRequest);
+        //   await tx.wait();
+        // });
 
         it("should issue correct amount of set tokens", async () => {
           const initialBalanceOfSet = await setToken.balanceOf(owner.address);

--- a/test/exchangeIssuance/exchangeIssuanceZeroEx.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuanceZeroEx.spec.ts
@@ -21,6 +21,8 @@ import {
   WETH9,
 } from "@utils/contracts/index";
 import { getAllowances } from "@utils/common/exchangeIssuanceUtils";
+import axios from "axios";
+import qs from "qs";
 
 const expect = getWaffleExpect();
 
@@ -66,234 +68,194 @@ describe("ExchangeIssuanceZeroEx", async () => {
     await setV2Setup.issuanceModule.initialize(setToken.address, ADDRESS_ZERO);
   });
 
-  describe("#constructor", async () => {
-    let subjectWethAddress: Address;
-    let subjectControllerAddress: Address;
-    let subjectBasicIssuanceModuleAddress: Address;
-    let subjectSwapTarget: Address;
-
-    cacheBeforeEach(async () => {
-      subjectWethAddress = weth.address;
-      subjectBasicIssuanceModuleAddress = setV2Setup.issuanceModule.address;
-      subjectControllerAddress = setV2Setup.controller.address;
-      subjectSwapTarget = zeroExMock.address;
-    });
-
-    async function subject(): Promise<ExchangeIssuanceZeroEx> {
-      return await deployer.extensions.deployExchangeIssuanceZeroEx(
-        subjectWethAddress,
-        subjectControllerAddress,
-        subjectBasicIssuanceModuleAddress,
-        subjectSwapTarget,
-      );
-    }
-
-    it("verify state set properly via constructor", async () => {
-      const exchangeIssuanceContract: ExchangeIssuanceZeroEx = await subject();
-
-      const expectedWethAddress = await exchangeIssuanceContract.WETH();
-      expect(expectedWethAddress).to.eq(subjectWethAddress);
-
-      const expectedControllerAddress = await exchangeIssuanceContract.setController();
-      expect(expectedControllerAddress).to.eq(subjectControllerAddress);
-
-      const expectedBasicIssuanceModuleAddress = await exchangeIssuanceContract.basicIssuanceModule();
-      expect(expectedBasicIssuanceModuleAddress).to.eq(subjectBasicIssuanceModuleAddress);
-
-      const swapTarget = await exchangeIssuanceContract.swapTarget();
-      expect(swapTarget).to.eq(subjectSwapTarget);
-    });
-  });
-
-  context("when exchange issuance is deployed", async () => {
-    let wethAddress: Address;
-    let controllerAddress: Address;
-    let basicIssuanceModuleAddress: Address;
-    let exchangeIssuanceZeroEx: ExchangeIssuanceZeroEx;
-
-    cacheBeforeEach(async () => {
-      wethAddress = weth.address;
-      controllerAddress = setV2Setup.controller.address;
-      basicIssuanceModuleAddress = setV2Setup.issuanceModule.address;
-      exchangeIssuanceZeroEx = await deployer.extensions.deployExchangeIssuanceZeroEx(
-        wethAddress,
-        controllerAddress,
-        basicIssuanceModuleAddress,
-        zeroExMock.address,
-      );
-    });
-
-    describe("#approveSetToken", async () => {
-      let subjectSetToApprove: SetToken | StandardTokenMock;
-
-      beforeEach(async () => {
-        subjectSetToApprove = setToken;
-      });
-
-      async function subject(): Promise<ContractTransaction> {
-        return await exchangeIssuanceZeroEx.approveSetToken(subjectSetToApprove.address);
-      }
-      it("should update the approvals correctly", async () => {
-        const tokens = [dai, dai];
-        const spenders = [basicIssuanceModuleAddress];
-
-        await subject();
-
-        const finalAllowances = await getAllowances(
-          tokens,
-          exchangeIssuanceZeroEx.address,
-          spenders,
-        );
-
-        for (let i = 0; i < finalAllowances.length; i++) {
-          const actualAllowance = finalAllowances[i];
-          const expectedAllowance = MAX_UINT_96;
-          expect(actualAllowance).to.eq(expectedAllowance);
-        }
-      });
-
-      context("when the input token is not a set", async () => {
-        beforeEach(async () => {
-          subjectSetToApprove = dai;
-        });
-
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("ExchangeIssuance: INVALID SET");
-        });
-      });
-    });
-
-    describe("#setSwapTarget", async () => {
+  if (!process.env.INTEGRATIONTEST) {
+    describe("#constructor", async () => {
+      let subjectWethAddress: Address;
+      let subjectControllerAddress: Address;
+      let subjectBasicIssuanceModuleAddress: Address;
       let subjectSwapTarget: Address;
 
-      beforeEach(async () => {
-        subjectSwapTarget = await getRandomAddress();
+      cacheBeforeEach(async () => {
+        subjectWethAddress = weth.address;
+        subjectBasicIssuanceModuleAddress = setV2Setup.issuanceModule.address;
+        subjectControllerAddress = setV2Setup.controller.address;
+        subjectSwapTarget = zeroExMock.address;
       });
 
-      async function subject(): Promise<ContractTransaction> {
-        return await exchangeIssuanceZeroEx.setSwapTarget(subjectSwapTarget);
+      async function subject(): Promise<ExchangeIssuanceZeroEx> {
+        return await deployer.extensions.deployExchangeIssuanceZeroEx(
+          subjectWethAddress,
+          subjectControllerAddress,
+          subjectBasicIssuanceModuleAddress,
+          subjectSwapTarget,
+        );
       }
-      it("should update the swap target correctly", async () => {
-        await subject();
-        const swapTarget = await exchangeIssuanceZeroEx.swapTarget();
+
+      it("verify state set properly via constructor", async () => {
+        const exchangeIssuanceContract: ExchangeIssuanceZeroEx = await subject();
+
+        const expectedWethAddress = await exchangeIssuanceContract.WETH();
+        expect(expectedWethAddress).to.eq(subjectWethAddress);
+
+        const expectedControllerAddress = await exchangeIssuanceContract.setController();
+        expect(expectedControllerAddress).to.eq(subjectControllerAddress);
+
+        const expectedBasicIssuanceModuleAddress = await exchangeIssuanceContract.basicIssuanceModule();
+        expect(expectedBasicIssuanceModuleAddress).to.eq(subjectBasicIssuanceModuleAddress);
+
+        const swapTarget = await exchangeIssuanceContract.swapTarget();
         expect(swapTarget).to.eq(subjectSwapTarget);
       });
-
     });
 
-    describe("#issueExactSetFromToken", async () => {
-      let subjectInputToken: StandardTokenMock | WETH9;
-      let subjectInputTokenAmount: BigNumber;
-      let subjectWethAmount: BigNumber;
-      let subjectAmountSetToken: number;
-      let subjectAmountSetTokenWei: BigNumber;
-      let subjectInputSwapQuote: ZeroExSwapQuote;
-      let subjectPositionSwapQuotes: ZeroExSwapQuote[];
+    context("when exchange issuance is deployed", async () => {
+      let wethAddress: Address;
+      let controllerAddress: Address;
+      let basicIssuanceModuleAddress: Address;
+      let exchangeIssuanceZeroEx: ExchangeIssuanceZeroEx;
 
-      // Helper function to generate 0xAPI quote for UniswapV2
-      function getUniswapV2Quote(
-        sellToken: Address,
-        sellAmount: BigNumber,
-        buyToken: Address,
-        minBuyAmount: BigNumber,
-      ): ZeroExSwapQuote {
-        const isSushi = false;
-        return {
-          sellToken,
-          buyToken,
-          swapCallData: zeroExMock.interface.encodeFunctionData("sellToUniswap", [
-            [sellToken, buyToken],
-            sellAmount,
-            minBuyAmount,
-            isSushi,
-          ]),
-        };
-      }
-
-      const initializeSubjectVariables = async () => {
-        subjectInputTokenAmount = ether(1000);
-        subjectInputToken = dai;
-        subjectWethAmount = ether(1);
-        subjectAmountSetToken = 1;
-        subjectAmountSetTokenWei = ether(subjectAmountSetToken);
-        subjectInputSwapQuote = getUniswapV2Quote(
-          dai.address,
-          subjectInputTokenAmount,
-          weth.address,
-          subjectWethAmount,
+      cacheBeforeEach(async () => {
+        wethAddress = weth.address;
+        controllerAddress = setV2Setup.controller.address;
+        basicIssuanceModuleAddress = setV2Setup.issuanceModule.address;
+        exchangeIssuanceZeroEx = await deployer.extensions.deployExchangeIssuanceZeroEx(
+          wethAddress,
+          controllerAddress,
+          basicIssuanceModuleAddress,
+          zeroExMock.address,
         );
-
-        const positions = await setToken.getPositions();
-        subjectPositionSwapQuotes = positions.map(position =>
-          getUniswapV2Quote(
-            weth.address,
-            subjectWethAmount.div(2),
-            position.component,
-            position.unit.mul(subjectAmountSetToken),
-          ),
-        );
-      };
-
-      beforeEach(async () => {
-        initializeSubjectVariables();
-        await exchangeIssuanceZeroEx.approveSetToken(setToken.address);
-        dai.approve(exchangeIssuanceZeroEx.address, MAX_UINT_256);
-        await weth.transfer(zeroExMock.address, subjectWethAmount);
-        await wbtc.transfer(zeroExMock.address, wbtcUnits.mul(subjectAmountSetToken));
-        await dai.transfer(zeroExMock.address, daiUnits.mul(subjectAmountSetToken));
       });
 
-      async function subject(): Promise<ContractTransaction> {
-        return await exchangeIssuanceZeroEx.issueExactSetFromToken(
-          setToken.address,
-          subjectInputToken.address,
-          subjectInputSwapQuote,
-          subjectAmountSetTokenWei,
-          subjectInputTokenAmount,
-          subjectPositionSwapQuotes,
-        );
-      }
+      describe("#approveSetToken", async () => {
+        let subjectSetToApprove: SetToken | StandardTokenMock;
 
-      it("should issue correct amount of set tokens", async () => {
-        const initialBalanceOfSet = await setToken.balanceOf(owner.address);
-        await subject();
-        const finalSetBalance = await setToken.balanceOf(owner.address);
-        const expectedSetBalance = initialBalanceOfSet.add(subjectAmountSetTokenWei);
-        expect(finalSetBalance).to.eq(expectedSetBalance);
-      });
-
-      it("should use correct amount of input tokens", async () => {
-        const initialBalanceOfInput = await subjectInputToken.balanceOf(owner.address);
-        await subject();
-        const finalInputBalance = await subjectInputToken.balanceOf(owner.address);
-        const expectedInputBalance = initialBalanceOfInput.sub(subjectInputTokenAmount);
-        expect(finalInputBalance).to.eq(expectedInputBalance);
-      });
-
-      context("when the input swap generates surplus WETH", async () => {
         beforeEach(async () => {
-          await weth.transfer(zeroExMock.address, subjectWethAmount);
-          await zeroExMock.setBuyMultiplier(weth.address, ether(2));
+          subjectSetToApprove = setToken;
         });
-        it("should return surplus WETH to user", async () => {
-          const initialBalanceOfSet = await setToken.balanceOf(owner.address);
-          const wethBalanceBefore = await weth.balanceOf(owner.address);
+
+        async function subject(): Promise<ContractTransaction> {
+          return await exchangeIssuanceZeroEx.approveSetToken(subjectSetToApprove.address);
+        }
+        it("should update the approvals correctly", async () => {
+          const tokens = [dai, dai];
+          const spenders = [basicIssuanceModuleAddress];
+
           await subject();
-          const finalSetBalance = await setToken.balanceOf(owner.address);
-          const wethBalanceAfter = await weth.balanceOf(owner.address);
-          const expectedSetBalance = initialBalanceOfSet.add(subjectAmountSetTokenWei);
-          const expectedWethBalance = wethBalanceBefore.add(subjectWethAmount);
-          expect(wethBalanceAfter).to.equal(expectedWethBalance);
-          expect(finalSetBalance).to.eq(expectedSetBalance);
+
+          const finalAllowances = await getAllowances(
+            tokens,
+            exchangeIssuanceZeroEx.address,
+            spenders,
+          );
+
+          for (let i = 0; i < finalAllowances.length; i++) {
+            const actualAllowance = finalAllowances[i];
+            const expectedAllowance = MAX_UINT_96;
+            expect(actualAllowance).to.eq(expectedAllowance);
+          }
+        });
+
+        context("when the input token is not a set", async () => {
+          beforeEach(async () => {
+            subjectSetToApprove = dai;
+          });
+
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith("ExchangeIssuance: INVALID SET");
+          });
         });
       });
 
-      context("when the input token is weth", async () => {
+      describe("#setSwapTarget", async () => {
+        let subjectSwapTarget: Address;
+
         beforeEach(async () => {
-          subjectInputToken = weth;
-          subjectInputTokenAmount = subjectWethAmount;
-          await weth.approve(exchangeIssuanceZeroEx.address, subjectInputTokenAmount);
+          subjectSwapTarget = await getRandomAddress();
         });
+
+        async function subject(): Promise<ContractTransaction> {
+          return await exchangeIssuanceZeroEx.setSwapTarget(subjectSwapTarget);
+        }
+        it("should update the swap target correctly", async () => {
+          await subject();
+          const swapTarget = await exchangeIssuanceZeroEx.swapTarget();
+          expect(swapTarget).to.eq(subjectSwapTarget);
+        });
+      });
+
+      describe("#issueExactSetFromToken", async () => {
+        let subjectInputToken: StandardTokenMock | WETH9;
+        let subjectInputTokenAmount: BigNumber;
+        let subjectWethAmount: BigNumber;
+        let subjectAmountSetToken: number;
+        let subjectAmountSetTokenWei: BigNumber;
+        let subjectInputSwapQuote: ZeroExSwapQuote;
+        let subjectPositionSwapQuotes: ZeroExSwapQuote[];
+
+        // Helper function to generate 0xAPI quote for UniswapV2
+        function getUniswapV2Quote(
+          sellToken: Address,
+          sellAmount: BigNumber,
+          buyToken: Address,
+          minBuyAmount: BigNumber,
+        ): ZeroExSwapQuote {
+          const isSushi = false;
+          return {
+            sellToken,
+            buyToken,
+            swapCallData: zeroExMock.interface.encodeFunctionData("sellToUniswap", [
+              [sellToken, buyToken],
+              sellAmount,
+              minBuyAmount,
+              isSushi,
+            ]),
+          };
+        }
+
+        const initializeSubjectVariables = async () => {
+          subjectInputTokenAmount = ether(1000);
+          subjectInputToken = dai;
+          subjectWethAmount = ether(1);
+          subjectAmountSetToken = 1;
+          subjectAmountSetTokenWei = ether(subjectAmountSetToken);
+          subjectInputSwapQuote = getUniswapV2Quote(
+            dai.address,
+            subjectInputTokenAmount,
+            weth.address,
+            subjectWethAmount,
+          );
+
+          const positions = await setToken.getPositions();
+          subjectPositionSwapQuotes = positions.map(position =>
+            getUniswapV2Quote(
+              weth.address,
+              subjectWethAmount.div(2),
+              position.component,
+              position.unit.mul(subjectAmountSetToken),
+            ),
+          );
+        };
+
+        beforeEach(async () => {
+          initializeSubjectVariables();
+          await exchangeIssuanceZeroEx.approveSetToken(setToken.address);
+          dai.approve(exchangeIssuanceZeroEx.address, MAX_UINT_256);
+          await weth.transfer(zeroExMock.address, subjectWethAmount);
+          await wbtc.transfer(zeroExMock.address, wbtcUnits.mul(subjectAmountSetToken));
+          await dai.transfer(zeroExMock.address, daiUnits.mul(subjectAmountSetToken));
+        });
+
+        async function subject(): Promise<ContractTransaction> {
+          return await exchangeIssuanceZeroEx.issueExactSetFromToken(
+            setToken.address,
+            subjectInputToken.address,
+            subjectInputSwapQuote,
+            subjectAmountSetTokenWei,
+            subjectInputTokenAmount,
+            subjectPositionSwapQuotes,
+          );
+        }
+
         it("should issue correct amount of set tokens", async () => {
           const initialBalanceOfSet = await setToken.balanceOf(owner.address);
           await subject();
@@ -301,6 +263,7 @@ describe("ExchangeIssuanceZeroEx", async () => {
           const expectedSetBalance = initialBalanceOfSet.add(subjectAmountSetTokenWei);
           expect(finalSetBalance).to.eq(expectedSetBalance);
         });
+
         it("should use correct amount of input tokens", async () => {
           const initialBalanceOfInput = await subjectInputToken.balanceOf(owner.address);
           await subject();
@@ -308,75 +271,295 @@ describe("ExchangeIssuanceZeroEx", async () => {
           const expectedInputBalance = initialBalanceOfInput.sub(subjectInputTokenAmount);
           expect(finalInputBalance).to.eq(expectedInputBalance);
         });
-      });
 
-      context("when a position quote is missing", async () => {
-        beforeEach(async () => {
-          subjectPositionSwapQuotes = [subjectPositionSwapQuotes[0]];
+        context("when the input swap generates surplus WETH", async () => {
+          beforeEach(async () => {
+            await weth.transfer(zeroExMock.address, subjectWethAmount);
+            await zeroExMock.setBuyMultiplier(weth.address, ether(2));
+          });
+          it("should return surplus WETH to user", async () => {
+            const initialBalanceOfSet = await setToken.balanceOf(owner.address);
+            const wethBalanceBefore = await weth.balanceOf(owner.address);
+            await subject();
+            const finalSetBalance = await setToken.balanceOf(owner.address);
+            const wethBalanceAfter = await weth.balanceOf(owner.address);
+            const expectedSetBalance = initialBalanceOfSet.add(subjectAmountSetTokenWei);
+            const expectedWethBalance = wethBalanceBefore.add(subjectWethAmount);
+            expect(wethBalanceAfter).to.equal(expectedWethBalance);
+            expect(finalSetBalance).to.eq(expectedSetBalance);
+          });
         });
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("WRONG NUMBER OF COMPONENT QUOTES");
-        });
-      });
 
-      context("when a position quote has the wrong buyTokenAddress", async () => {
-        beforeEach(async () => {
-          subjectPositionSwapQuotes[0].buyToken = await getRandomAddress();
+        context("when the input token is weth", async () => {
+          beforeEach(async () => {
+            subjectInputToken = weth;
+            subjectInputTokenAmount = subjectWethAmount;
+            await weth.approve(exchangeIssuanceZeroEx.address, subjectInputTokenAmount);
+          });
+          it("should issue correct amount of set tokens", async () => {
+            const initialBalanceOfSet = await setToken.balanceOf(owner.address);
+            await subject();
+            const finalSetBalance = await setToken.balanceOf(owner.address);
+            const expectedSetBalance = initialBalanceOfSet.add(subjectAmountSetTokenWei);
+            expect(finalSetBalance).to.eq(expectedSetBalance);
+          });
+          it("should use correct amount of input tokens", async () => {
+            const initialBalanceOfInput = await subjectInputToken.balanceOf(owner.address);
+            await subject();
+            const finalInputBalance = await subjectInputToken.balanceOf(owner.address);
+            const expectedInputBalance = initialBalanceOfInput.sub(subjectInputTokenAmount);
+            expect(finalInputBalance).to.eq(expectedInputBalance);
+          });
         });
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("COMPONENT / QUOTE ADDRESS MISMATCH");
-        });
-      });
 
-      context("when a position quote has a non-WETH sellToken address", async () => {
-        beforeEach(async () => {
-          subjectPositionSwapQuotes[0].sellToken = await getRandomAddress();
+        context("when a position quote is missing", async () => {
+          beforeEach(async () => {
+            subjectPositionSwapQuotes = [subjectPositionSwapQuotes[0]];
+          });
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith("WRONG NUMBER OF COMPONENT QUOTES");
+          });
         });
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("INVALID SELL TOKEN");
-        });
-      });
 
-      context("when the input swap yields insufficient WETH", async () => {
-        beforeEach(async () => {
-          await zeroExMock.setBuyMultiplier(weth.address, ether(0.5));
+        context("when a position quote has the wrong buyTokenAddress", async () => {
+          beforeEach(async () => {
+            subjectPositionSwapQuotes[0].buyToken = await getRandomAddress();
+          });
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith("COMPONENT / QUOTE ADDRESS MISMATCH");
+          });
         });
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("SWAP CALL FAILED");
-        });
-      });
 
-      context("when a component swap spends too much weth", async () => {
-        beforeEach(async () => {
-          // Simulate left over weth balance left in contract
-          await weth.transfer(exchangeIssuanceZeroEx.address, subjectWethAmount);
-          await zeroExMock.setSellMultiplier(weth.address, ether(2));
+        context("when a position quote has a non-WETH sellToken address", async () => {
+          beforeEach(async () => {
+            subjectPositionSwapQuotes[0].sellToken = await getRandomAddress();
+          });
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith("INVALID SELL TOKEN");
+          });
         });
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("OVERSPENT WETH");
-        });
-      });
 
-      context("when a component swap yields insufficient component token", async () => {
-        beforeEach(async () => {
-          // Simulating left over component balance left in contract
-          await wbtc.transfer(exchangeIssuanceZeroEx.address, wbtcUnits);
-          await zeroExMock.setBuyMultiplier(wbtc.address, ether(0.5));
+        context("when the input swap yields insufficient WETH", async () => {
+          beforeEach(async () => {
+            await zeroExMock.setBuyMultiplier(weth.address, ether(0.5));
+          });
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith("SWAP CALL FAILED");
+          });
         });
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("UNDERBOUGHT COMPONENT");
-        });
-      });
 
-      context("when a swap call fails", async () => {
-        beforeEach(async () => {
-          // Trigger revertion in mock by trying to return more buy tokens than available in balance
-          await zeroExMock.setBuyMultiplier(wbtc.address, ether(100));
+        context("when a component swap spends too much weth", async () => {
+          beforeEach(async () => {
+            // Simulate left over weth balance left in contract
+            await weth.transfer(exchangeIssuanceZeroEx.address, subjectWethAmount);
+            await zeroExMock.setSellMultiplier(weth.address, ether(2));
+          });
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith("OVERSPENT WETH");
+          });
         });
-        it("should revert", async () => {
-          await expect(subject()).to.be.revertedWith("SWAP CALL FAILED");
+
+        context("when a component swap yields insufficient component token", async () => {
+          beforeEach(async () => {
+            // Simulating left over component balance left in contract
+            await wbtc.transfer(exchangeIssuanceZeroEx.address, wbtcUnits);
+            await zeroExMock.setBuyMultiplier(wbtc.address, ether(0.5));
+          });
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith("UNDERBOUGHT COMPONENT");
+          });
+        });
+
+        context("when a swap call fails", async () => {
+          beforeEach(async () => {
+            // Trigger revertion in mock by trying to return more buy tokens than available in balance
+            await zeroExMock.setBuyMultiplier(wbtc.address, ether(100));
+          });
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith("SWAP CALL FAILED");
+          });
         });
       });
     });
-  });
+  }
+  if (process.env.INTEGRATIONTEST) {
+    context("integration tests", async () => {
+      let wethAddress: Address;
+      let wbtcAddress: Address;
+      let daiAddress: Address;
+      let basicIssuanceModuleAddress: Address;
+      let exchangeIssuanceZeroEx: ExchangeIssuanceZeroEx;
+      let zeroExProxyAddress: Address;
+      let setToken: SetToken;
+
+      cacheBeforeEach(async () => {
+        // Mainnet addresses
+        wethAddress = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
+        daiAddress = "0x6b175474e89094c44da98b954eedeac495271d0f";
+        wbtcAddress = "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599";
+        basicIssuanceModuleAddress = "0xd8EF3cACe8b4907117a45B0b125c68560532F94D";
+        zeroExProxyAddress = "0xDef1C0ded9bec7F1a1670819833240f027b25EfF";
+
+        dai = dai.attach(daiAddress);
+        weth = weth.attach(wethAddress);
+        wbtc = wbtc.attach(wbtcAddress);
+        setToken = await setV2Setup.createSetToken(
+          [daiAddress, wbtcAddress],
+          [daiUnits, wbtcUnits],
+          [setV2Setup.issuanceModule.address, setV2Setup.streamingFeeModule.address],
+        );
+
+        exchangeIssuanceZeroEx = await deployer.extensions.deployExchangeIssuanceZeroEx(
+          wethAddress,
+          setV2Setup.controller.address,
+          setV2Setup.issuanceModule.address,
+          zeroExProxyAddress,
+        );
+        await setV2Setup.issuanceModule.initialize(setToken.address, ADDRESS_ZERO);
+      });
+
+      describe("#approveSetToken", async () => {
+        let subjectSetToApprove: SetToken | StandardTokenMock;
+
+        beforeEach(async () => {
+          subjectSetToApprove = setToken;
+        });
+
+        async function subject(): Promise<ContractTransaction> {
+          return await exchangeIssuanceZeroEx.approveSetToken(subjectSetToApprove.address);
+        }
+        it("should update the approvals correctly", async () => {
+          const tokens = [dai, wbtc];
+          const spenders = [basicIssuanceModuleAddress];
+
+          await subject();
+
+          const finalAllowances = await getAllowances(
+            tokens,
+            exchangeIssuanceZeroEx.address,
+            spenders,
+          );
+
+          for (let i = 0; i < finalAllowances.length; i++) {
+            const actualAllowance = finalAllowances[i];
+            const expectedAllowance = MAX_UINT_96;
+            expect(actualAllowance).to.eq(expectedAllowance);
+          }
+        });
+
+        context("when the input token is not a set", async () => {
+          beforeEach(async () => {
+            subjectSetToApprove = dai;
+          });
+
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith("ExchangeIssuance: INVALID SET");
+          });
+        });
+      });
+
+      describe("#setSwapTarget", async () => {
+        let subjectSwapTarget: Address;
+
+        beforeEach(async () => {
+          subjectSwapTarget = await getRandomAddress();
+        });
+
+        async function subject(): Promise<ContractTransaction> {
+          return await exchangeIssuanceZeroEx.setSwapTarget(subjectSwapTarget);
+        }
+        it("should update the swap target correctly", async () => {
+          await subject();
+          const swapTarget = await exchangeIssuanceZeroEx.swapTarget();
+          expect(swapTarget).to.eq(subjectSwapTarget);
+        });
+      });
+
+      describe("#issueExactSetFromToken", async () => {
+        let subjectInputToken: StandardTokenMock | WETH9;
+        let subjectInputTokenAmount: BigNumber;
+        let subjectAmountSetToken: number;
+        let subjectAmountSetTokenWei: BigNumber;
+        let subjectInputSwapQuote: ZeroExSwapQuote;
+        let subjectPositionSwapQuotes: ZeroExSwapQuote[];
+
+        const API_QUOTE_URL = "https://api.0x.org/swap/v1/quote";
+        async function getQuote(params: any) {
+          const url = `${API_QUOTE_URL}?${qs.stringify(params)}`;
+          console.log("Sending quote request to:", url);
+          const response = await axios(url);
+          console.log("Response:", response.data);
+          return response.data;
+        }
+
+        // Helper function to generate 0xAPI quote for UniswapV2
+        async function getQuotes(
+          setToken: SetToken,
+          inputTokenAddress: Address,
+          setAmount: number,
+        ) {
+          const positions = await setToken.getPositions();
+          const positionQuotes: ZeroExSwapQuote[] = [];
+          let buyAmountWeth = BigNumber.from(0);
+
+          console.log("Getting quotes for component trades");
+          for (const position of positions) {
+            const buyAmount = position.unit.mul(setAmount).toString();
+            const buyToken = position.component;
+            const sellToken = wethAddress;
+            const quote = await getQuote({ buyToken, sellToken, buyAmount });
+            console.log("Received Quote", quote);
+            positionQuotes.push(quote);
+            buyAmountWeth = buyAmountWeth.add(BigNumber.from(quote.sellAmount));
+          }
+
+          console.log("Getting quote for input token trade");
+          const inputQuote = await getQuote({
+            buyToken: wethAddress,
+            sellToken: inputTokenAddress,
+            buyAmount: buyAmountWeth.toString(),
+          });
+          const inputTokenAmount = inputQuote.sellAmount;
+          return [inputQuote, positionQuotes, inputTokenAmount];
+        }
+
+        const initializeSubjectVariables = async () => {
+          subjectInputTokenAmount = ether(1000);
+          subjectInputToken = dai;
+          subjectAmountSetToken = 1;
+          subjectAmountSetTokenWei = ether(subjectAmountSetToken);
+          [subjectInputSwapQuote, subjectPositionSwapQuotes, subjectInputTokenAmount] = await getQuotes(
+            setToken,
+            subjectInputToken.address,
+            subjectAmountSetToken,
+          );
+        };
+
+        beforeEach(async () => {
+          await initializeSubjectVariables();
+          await exchangeIssuanceZeroEx.approveSetToken(setToken.address);
+          dai.approve(exchangeIssuanceZeroEx.address, MAX_UINT_256);
+        });
+
+        async function subject(): Promise<ContractTransaction> {
+          return await exchangeIssuanceZeroEx.issueExactSetFromToken(
+            setToken.address,
+            subjectInputToken.address,
+            subjectInputSwapQuote as any,
+            subjectAmountSetTokenWei,
+            subjectInputTokenAmount,
+            subjectPositionSwapQuotes as any,
+          );
+        }
+
+        it("should issue correct amount of set tokens", async () => {
+          const initialBalanceOfSet = await setToken.balanceOf(owner.address);
+          await subject();
+          const finalSetBalance = await setToken.balanceOf(owner.address);
+          const expectedSetBalance = initialBalanceOfSet.add(subjectAmountSetTokenWei);
+          expect(finalSetBalance).to.eq(expectedSetBalance);
+        });
+      });
+    });
+  }
 });

--- a/test/exchangeIssuance/exchangeIssuanceZeroEx.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuanceZeroEx.spec.ts
@@ -186,7 +186,10 @@ describe("ExchangeIssuanceZeroEx", async () => {
             });
             buyAmountWeth = buyAmountWeth.add(BigNumber.from(quote.sellAmount));
           }
-          buyAmountWeth = buyAmountWeth.mul(100 + slippagePercents).div(100);
+          // I assume that this is the correct math to make sure we have enough weth to cover the slippage
+          // based on the fact that the slippagePercentage is limited between 0.0 and 1.0 on the 0xApi
+          // TODO: Review if correct
+          buyAmountWeth = buyAmountWeth.mul(100).div(100 - slippagePercents);
 
           console.log("\n\n###################INPUT TOKEN QUOTE##################");
           const inputTokenApiResponse = await getQuote({
@@ -197,7 +200,8 @@ describe("ExchangeIssuanceZeroEx", async () => {
             slippagePercentage,
           });
           await logQuote(inputTokenApiResponse);
-          const inputTokenAmount = BigNumber.from(inputTokenApiResponse.sellAmount);
+          let inputTokenAmount = BigNumber.from(inputTokenApiResponse.sellAmount);
+          inputTokenAmount = inputTokenAmount.mul(100).div(100 - slippagePercents);
           console.log("Input token amount", inputTokenAmount.toString());
           const inputQuote = {
             buyToken: wethAddress,
@@ -246,7 +250,6 @@ describe("ExchangeIssuanceZeroEx", async () => {
             (await subjectInputToken.balanceOf(owner.address)).toString(),
           );
           subjectInputToken.approve(exchangeIssuanceZeroEx.address, MAX_UINT_256);
-          subjectInputTokenAmount = await subjectInputToken.balanceOf(owner.address);
         });
 
         async function subject(): Promise<ContractTransaction> {

--- a/test/exchangeIssuance/exchangeIssuanceZeroEx.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuanceZeroEx.spec.ts
@@ -532,6 +532,8 @@ describe("ExchangeIssuanceZeroEx", async () => {
           inputTokenAddress: Address,
           setAmount: number,
           inputTokenMultiplierPercentage: number,
+          wethMultiplierPercentage: number,
+          excludedSources: string | undefined = undefined,
         ): Promise<[ZeroExSwapQuote, ZeroExSwapQuote[], BigNumber]> {
           const positions = await setToken.getPositions();
           const positionQuotes: ZeroExSwapQuote[] = [];
@@ -542,7 +544,7 @@ describe("ExchangeIssuanceZeroEx", async () => {
             const buyAmount = position.unit.mul(setAmount).toString();
             const buyToken = position.component;
             const sellToken = wethAddress;
-            const quote = await getQuote({ buyToken, sellToken, buyAmount });
+            const quote = await getQuote({ buyToken, sellToken, buyAmount, excludedSources });
             await logQuote(quote);
             positionQuotes.push({
               sellToken: sellToken,
@@ -551,6 +553,8 @@ describe("ExchangeIssuanceZeroEx", async () => {
             });
             buyAmountWeth = buyAmountWeth.add(BigNumber.from(quote.sellAmount));
           }
+
+          buyAmountWeth = buyAmountWeth.mul(wethMultiplierPercentage).div(100);
 
           console.log("\n\n###################INPUT TOKEN QUOTE##################");
           const inputTokenApiResponse = await getQuote({
@@ -576,6 +580,10 @@ describe("ExchangeIssuanceZeroEx", async () => {
           // so we add some margin for extra safety
           // TODO: Review to understand why this happens and how to handle in production
           const INPUT_TOKEN_MULTIPLIER_PERCENTAGE = 110;
+          const WETH_MULTIPLIER_PERCENTAGE = 110;
+          // During testing swaps including Sushi frequently reverted, so excluding it for now
+          // TODO: Review to understand why this happens and how to handle in production
+          const EXCLUDED_SOURCES = "SushiSwap";
 
           subjectInputToken = dai;
           subjectAmountSetToken = 1;
@@ -589,6 +597,8 @@ describe("ExchangeIssuanceZeroEx", async () => {
             subjectInputToken.address,
             subjectAmountSetToken,
             INPUT_TOKEN_MULTIPLIER_PERCENTAGE,
+            WETH_MULTIPLIER_PERCENTAGE,
+            EXCLUDED_SOURCES,
           );
         };
 

--- a/test/exchangeIssuance/exchangeIssuanceZeroExIntegrationTest.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuanceZeroExIntegrationTest.spec.ts
@@ -47,7 +47,6 @@ describe("ExchangeIssuanceZeroEx", async () => {
 
     ({ dai, wbtc, weth } = setV2Setup);
 
-    zeroExMock = await deployer.mocks.deployZeroExExchangeProxyMock();
 
     daiUnits = BigNumber.from("23252699054621733");
     wbtcUnits = UnitsUtils.wbtc(1);

--- a/test/exchangeIssuance/exchangeIssuanceZeroExIntegrationTest.spec.ts
+++ b/test/exchangeIssuance/exchangeIssuanceZeroExIntegrationTest.spec.ts
@@ -1,0 +1,266 @@
+import "module-alias/register";
+import { Address, Account } from "@utils/types";
+import { ADDRESS_ZERO, MAX_UINT_256 } from "@utils/constants";
+import { SetToken } from "@utils/contracts/setV2";
+import { cacheBeforeEach, ether, getAccounts, getSetFixture, getWaffleExpect } from "@utils/index";
+import DeployHelper from "@utils/deploys";
+import { UnitsUtils } from "@utils/common/unitsUtils";
+import { SetFixture } from "@utils/fixtures";
+import { BigNumber, ContractTransaction } from "ethers";
+import {
+  ExchangeIssuanceZeroEx,
+  StandardTokenMock,
+  WETH9,
+} from "@utils/contracts/index";
+import axios from "axios";
+import qs from "qs";
+import hre, { ethers } from "hardhat";
+
+const expect = getWaffleExpect();
+
+type ZeroExSwapQuote = {
+  sellToken: Address;
+  buyToken: Address;
+  swapCallData: string;
+};
+
+describe("ExchangeIssuanceZeroEx", async () => {
+  let owner: Account;
+
+  let setV2Setup: SetFixture;
+  let deployer: DeployHelper;
+
+  let setToken: SetToken;
+  let wbtc: StandardTokenMock;
+  let dai: StandardTokenMock;
+  let weth: WETH9;
+
+  let daiUnits: BigNumber;
+  let wbtcUnits: BigNumber;
+
+  cacheBeforeEach(async () => {
+    [owner] = await getAccounts();
+    deployer = new DeployHelper(owner.wallet);
+
+    setV2Setup = getSetFixture(owner.address);
+    await setV2Setup.initialize();
+
+    ({ dai, wbtc, weth } = setV2Setup);
+
+    zeroExMock = await deployer.mocks.deployZeroExExchangeProxyMock();
+
+    daiUnits = BigNumber.from("23252699054621733");
+    wbtcUnits = UnitsUtils.wbtc(1);
+    setToken = await setV2Setup.createSetToken(
+      [dai.address, wbtc.address],
+      [daiUnits, wbtcUnits],
+      [setV2Setup.issuanceModule.address, setV2Setup.streamingFeeModule.address],
+    );
+    await setV2Setup.issuanceModule.initialize(setToken.address, ADDRESS_ZERO);
+  });
+
+  if (process.env.INTEGRATIONTEST) {
+    context("integration tests", async () => {
+      let wethAddress: Address;
+      let wbtcAddress: Address;
+      let daiAddress: Address;
+      let exchangeIssuanceZeroEx: ExchangeIssuanceZeroEx;
+      let zeroExProxyAddress: Address;
+      let setToken: SetToken;
+
+      cacheBeforeEach(async () => {
+        // Mainnet addresses
+        wethAddress = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
+        daiAddress = "0x6b175474e89094c44da98b954eedeac495271d0f";
+        wbtcAddress = "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599";
+        zeroExProxyAddress = "0xDef1C0ded9bec7F1a1670819833240f027b25EfF";
+
+        dai = dai.attach(daiAddress);
+        weth = weth.attach(wethAddress);
+        wbtc = wbtc.attach(wbtcAddress);
+        setToken = await setV2Setup.createSetToken(
+          [daiAddress, wbtcAddress],
+          [daiUnits, wbtcUnits],
+          [setV2Setup.issuanceModule.address, setV2Setup.streamingFeeModule.address],
+        );
+
+        exchangeIssuanceZeroEx = await deployer.extensions.deployExchangeIssuanceZeroEx(
+          wethAddress,
+          setV2Setup.controller.address,
+          setV2Setup.issuanceModule.address,
+          zeroExProxyAddress,
+        );
+        await setV2Setup.issuanceModule.initialize(setToken.address, ADDRESS_ZERO);
+      });
+
+      describe("#issueExactSetFromToken", async () => {
+        let subjectInputToken: StandardTokenMock | WETH9;
+        let subjectInputTokenAmount: BigNumber;
+        let subjectAmountSetToken: number;
+        let subjectAmountSetTokenWei: BigNumber;
+        let subjectInputSwapQuote: ZeroExSwapQuote;
+        let subjectPositionSwapQuotes: ZeroExSwapQuote[];
+
+        const API_QUOTE_URL = "https://api.0x.org/swap/v1/quote";
+        async function getQuote(params: any) {
+          const url = `${API_QUOTE_URL}?${qs.stringify(params)}`;
+          console.log(`Getting quote from ${params.sellToken} to ${params.buyToken}`);
+          console.log("Sending quote request to:", url);
+          const response = await axios(url);
+          return response.data;
+        }
+
+        async function logQuote(quote: any) {
+          console.log("Sell Amount:", quote.sellAmount);
+          console.log("Buy Amount:", quote.buyAmount);
+          console.log("Swap Target:", quote.to);
+          console.log("Allowance Target:", quote.allowanceTarget);
+          console.log(
+            "Sources:",
+            quote.sources.filter((source: any) => source.proportion > "0"),
+          );
+          await decodeCallData(quote.data, quote.to);
+        }
+
+        async function decodeCallData(callData: string, proxyAddress: Address) {
+          const API_KEY = "X28YB9Z9TQD4KSSC6A6QTKHYGPYGIP8D7I";
+          const ABI_ENDPOINT = `https://api.etherscan.io/api?module=contract&action=getabi&apikey=${API_KEY}&address=`;
+          const proxyAbi = await axios
+            .get(ABI_ENDPOINT + proxyAddress)
+            .then(response => JSON.parse(response.data.result));
+          const proxyContract = await ethers.getContractAt(proxyAbi, proxyAddress);
+          await proxyContract.deployed();
+          const implementation = await proxyContract.getFunctionImplementation(
+            callData.slice(0, 10),
+          );
+          console.log("Implementation Address: ", implementation);
+          const abiResponse = await axios.get(ABI_ENDPOINT + implementation);
+          const abi = JSON.parse(abiResponse.data.result);
+          const iface = new ethers.utils.Interface(abi);
+          const decodedTransaction = iface.parseTransaction({
+            data: callData,
+          });
+          console.log("Called Function Signature: ", decodedTransaction.signature);
+        }
+
+        // Helper function to generate 0xAPI quote for UniswapV2
+        async function getQuotes(
+          setToken: SetToken,
+          inputTokenAddress: Address,
+          setAmount: number,
+          slippagePercents: number,
+          excludedSources: string | undefined = undefined,
+        ): Promise<[ZeroExSwapQuote, ZeroExSwapQuote[], BigNumber]> {
+          const positions = await setToken.getPositions();
+          const positionQuotes: ZeroExSwapQuote[] = [];
+          let buyAmountWeth = BigNumber.from(0);
+          const slippagePercentage = slippagePercents / 100;
+
+          for (const position of positions) {
+            console.log("\n\n###################COMPONENT QUOTE##################");
+            const buyAmount = position.unit.mul(setAmount).toString();
+            const buyToken = position.component;
+            const sellToken = wethAddress;
+            const quote = await getQuote({
+              buyToken,
+              sellToken,
+              buyAmount,
+              excludedSources,
+              slippagePercentage,
+            });
+            await logQuote(quote);
+            positionQuotes.push({
+              sellToken: sellToken,
+              buyToken: buyToken,
+              swapCallData: quote.data,
+            });
+            buyAmountWeth = buyAmountWeth.add(BigNumber.from(quote.sellAmount));
+          }
+          // I assume that this is the correct math to make sure we have enough weth to cover the slippage
+          // based on the fact that the slippagePercentage is limited between 0.0 and 1.0 on the 0xApi
+          // TODO: Review if correct
+          buyAmountWeth = buyAmountWeth.mul(100).div(100 - slippagePercents);
+
+          console.log("\n\n###################INPUT TOKEN QUOTE##################");
+          const inputTokenApiResponse = await getQuote({
+            buyToken: wethAddress,
+            sellToken: inputTokenAddress,
+            buyAmount: buyAmountWeth.toString(),
+            excludedSources,
+            slippagePercentage,
+          });
+          await logQuote(inputTokenApiResponse);
+          let inputTokenAmount = BigNumber.from(inputTokenApiResponse.sellAmount);
+          inputTokenAmount = inputTokenAmount.mul(100).div(100 - slippagePercents);
+          console.log("Input token amount", inputTokenAmount.toString());
+          const inputQuote = {
+            buyToken: wethAddress,
+            sellToken: inputTokenAddress,
+            swapCallData: inputTokenApiResponse.data,
+          };
+          return [inputQuote, positionQuotes, inputTokenAmount];
+        }
+
+        const initializeSubjectVariables = async () => {
+          // TODO: Analyse what a good value would be in production
+          const SLIPPAGE_PERCENTAGE = 50;
+
+          subjectInputToken = dai;
+          subjectAmountSetToken = 1;
+          subjectAmountSetTokenWei = ether(subjectAmountSetToken);
+          [
+            subjectInputSwapQuote,
+            subjectPositionSwapQuotes,
+            subjectInputTokenAmount,
+          ] = await getQuotes(
+            setToken,
+            subjectInputToken.address,
+            subjectAmountSetToken,
+            SLIPPAGE_PERCENTAGE,
+          );
+        };
+
+        beforeEach(async () => {
+          await initializeSubjectVariables();
+          await exchangeIssuanceZeroEx.approveSetToken(setToken.address);
+
+          console.log("\n\n###################OBTAIN INPUT TOKEN FROM WHALE##################");
+          const inputTokenWhaleAddress = "0x21a31Ee1afC51d94C2eFcCAa2092aD1028285549";
+          await hre.network.provider.request({
+            method: "hardhat_impersonateAccount",
+            params: [inputTokenWhaleAddress],
+          });
+          const inputTokenWhaleSigner = ethers.provider.getSigner(inputTokenWhaleAddress);
+          const whaleTokenBalance = await subjectInputToken.balanceOf(inputTokenWhaleAddress);
+          await subjectInputToken
+            .connect(inputTokenWhaleSigner)
+            .transfer(owner.address, whaleTokenBalance);
+          console.log(
+            "New owner balance",
+            (await subjectInputToken.balanceOf(owner.address)).toString(),
+          );
+          subjectInputToken.approve(exchangeIssuanceZeroEx.address, MAX_UINT_256);
+        });
+
+        async function subject(): Promise<ContractTransaction> {
+          return await exchangeIssuanceZeroEx.issueExactSetFromToken(
+            setToken.address,
+            subjectInputToken.address,
+            subjectInputSwapQuote,
+            subjectAmountSetTokenWei,
+            subjectInputTokenAmount,
+            subjectPositionSwapQuotes,
+          );
+        }
+
+        it("should issue correct amount of set tokens", async () => {
+          const initialBalanceOfSet = await setToken.balanceOf(owner.address);
+          await subject();
+          const finalSetBalance = await setToken.balanceOf(owner.address);
+          const expectedSetBalance = initialBalanceOfSet.add(subjectAmountSetTokenWei);
+          expect(finalSetBalance).to.eq(expectedSetBalance);
+        });
+      });
+    });
+  }
+});


### PR DESCRIPTION
To run test do the following:
1. Run a local chain forked off the latest mainnet block: `FORK=true LATESTBLOCK=true yarn chain;`
2. Run the integration tests: `INTEGRATIONTEST=true yarn test test/exchangeIssuance/exchangeIssuanceZeroEx.spec.ts
`

What will happen in the integration test:
1. Sample Set Token is deployed on the forked network. (Same as in unittest)
2. ExchangeIssuanceZeroEx is deployed pointing at the actual mainnet address of the 0xExchange Proxy
3. Inputoken (DAI) is obtained from Whale via hardhat impersonation and send to the test account
4. Quotes are obtained via http request form the actual 0xAPI
5. `issueExactSetFromToken` is triggered using  obtained quotes

Problems that were encountered:
1. Fixed Blocknumber lead to transaction failures since 0xAPI response is based on latest block (fixed by adding `LATESTBLOCK` env param
2. `issueExactSetFromToken` takes a long time leading to hardhat network or Mocha test timeouts  (still happens sometime even though I tried increasing all relevant timeout config params)
3. Swap Call failures were hard to debug (since the message was just "SWAP CALL FAILED") - fixed by forwarding the revertion reason  string.
4. Swap from Input Token to WETH failed with `UniswapV3Feature/Underbought` - fixed by adding a margin / multiplier to the maxAmoutnInputToken on top of what would be necessary according to API response.
5. Component Swaps fail sometimes (with empty reason string). Tried excluding "SushiSwap" and also adding a margin to the amount of WETH obtained but still hapens sometimes.
